### PR TITLE
Add package indexing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ export OPENAI_API_KEY="sk-your-key-here"
 # Index your codebase first (creates chunkhound.db in current directory)
 uv run chunkhound index
 
-# Index an installed package
-uv run chunkhound index --package requests
+# Index one or more installed packages
+uv run chunkhound index --package requests --package numpy
 
 # OR: Index and watch for changes (standalone mode)
 uv run chunkhound index --watch

--- a/chunkhound/api/cli/parsers/run_parser.py
+++ b/chunkhound/api/cli/parsers/run_parser.py
@@ -113,8 +113,8 @@ def add_run_subparser(subparsers: Any) -> argparse.ArgumentParser:
 
     run_parser.add_argument(
         "--package",
-        type=str,
-        help="Index an installed Python package instead of a directory",
+        action="append",
+        help="Index an installed Python package (can be used multiple times)",
     )
 
     # Add common argument groups

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -41,8 +41,8 @@ chunkhound run .
 # Index specific directory
 chunkhound run /path/to/your/project
 
-# Index an installed Python package
-chunkhound run --package requests
+# Index one or more installed Python packages
+chunkhound run --package requests --package numpy
 
 # Watch for changes in real-time
 chunkhound run . --watch

--- a/tests/test_package_resolution.py
+++ b/tests/test_package_resolution.py
@@ -1,7 +1,8 @@
 import importlib.util
+import importlib.metadata
 from pathlib import Path
 
-from chunkhound.api.cli.commands.run import _resolve_package_path
+from chunkhound.api.cli.commands.run import _resolve_package_path, _get_package_version
 
 
 def test_resolve_existing_package():
@@ -12,3 +13,8 @@ def test_resolve_existing_package():
 
 def test_resolve_missing_package():
     assert _resolve_package_path("nonexistent_pkg_12345") is None
+
+
+def test_get_package_version():
+    v = _get_package_version("pip")
+    assert v == importlib.metadata.version("pip")


### PR DESCRIPTION
## Summary
- allow `chunkhound run` to index installed Python packages
- expose helper `_resolve_package_path`
- document `--package` usage in README and CLI guide
- add simple unit test for package path resolution

## Testing
- `pytest -k package_resolution -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*
- `ruff check .` *(fails to run: shows many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68608fe653288328abf3ad0eca5da7e0