### PR TITLE
Add package indexing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ export OPENAI_API_KEY="sk-your-key-here"
 
 # Index your codebase first (creates chunkhound.db in current directory)
 uv run chunkhound index
+# Index a PyPI package
+uv run chunkhound package --pypi somepkg
+# Or index a GitHub repo
+uv run chunkhound package --github https://github.com/user/repo
 
 # OR: Index and watch for changes (standalone mode)
 uv run chunkhound index --watch

--- a/chunkhound/api/cli/__init__.py
+++ b/chunkhound/api/cli/__init__.py
@@ -6,4 +6,5 @@
 __all__ = [
     "run_command",
     "mcp_command",
+    "package_command",
 ]

--- a/chunkhound/api/cli/commands/package.py
+++ b/chunkhound/api/cli/commands/package.py
@@ -1,0 +1,58 @@
+"""Package command for ChunkHound."""
+
+import argparse
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from loguru import logger
+
+from .run import run_command
+
+
+async def package_command(args: argparse.Namespace) -> None:
+    """Download or clone a package and index it."""
+    if not args.pypi and not args.github:
+        logger.error("Specify --pypi or --github")
+        return
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+
+        if args.pypi:
+            logger.info(f"Downloading PyPI package: {args.pypi}")
+            install_dir = tmp_path / "pkg"
+            subprocess.run(
+                [
+                    "uv",
+                    "pip",
+                    "install",
+                    "--no-deps",
+                    "--no-compile",
+                    "--upgrade",
+                    "--target",
+                    str(install_dir),
+                    args.pypi,
+                ],
+                check=True,
+            )
+            package_dir = install_dir
+        else:
+            logger.info(f"Cloning repository: {args.github}")
+            repo_dir = tmp_path / "repo"
+            clone_cmd = ["git", "clone", "--depth", "1", args.github, str(repo_dir)]
+            if args.ref:
+                clone_cmd.extend(["--branch", args.ref])
+            subprocess.run(clone_cmd, check=True)
+            package_dir = repo_dir
+
+        index_args = argparse.Namespace(**vars(args))
+        index_args.path = package_dir
+        index_args.watch = False
+        index_args.initial_scan_only = False
+
+        await run_command(index_args)
+
+
+__all__: list[str] = ["package_command"]

--- a/chunkhound/api/cli/parsers/package_parser.py
+++ b/chunkhound/api/cli/parsers/package_parser.py
@@ -1,0 +1,72 @@
+import argparse
+from typing import Any, cast
+
+from .main_parser import (
+    add_common_arguments,
+    add_database_argument,
+    add_embedding_arguments,
+    add_file_pattern_arguments,
+)
+
+
+def add_package_subparser(subparsers: Any) -> argparse.ArgumentParser:
+    """Add package command subparser."""
+    parser = subparsers.add_parser(
+        "package",
+        help="Index a PyPI or GitHub package",
+        description=(
+            "Download a package from PyPI or clone a GitHub repository "
+            "and run ChunkHound indexing on it."
+        ),
+    )
+
+    add_common_arguments(parser)
+    add_database_argument(parser)
+    add_embedding_arguments(parser)
+    add_file_pattern_arguments(parser)
+
+    parser.add_argument(
+        "--pypi",
+        help="PyPI package name to download",
+    )
+    parser.add_argument(
+        "--github",
+        help="GitHub repository URL to clone",
+    )
+    parser.add_argument(
+        "--ref",
+        help="Git reference (branch or tag) to checkout",
+    )
+    parser.add_argument(
+        "--force-reindex",
+        action="store_true",
+        help="Force reindexing of all files",
+    )
+    parser.add_argument(
+        "--embedding-batch-size",
+        type=int,
+        default=100,
+        help="Number of text chunks per embedding API request (default: 100)",
+    )
+    parser.add_argument(
+        "--db-batch-size",
+        type=int,
+        default=500,
+        help="Number of records per database transaction (default: 500)",
+    )
+    parser.add_argument(
+        "--max-concurrent",
+        type=int,
+        default=3,
+        help="Maximum concurrent embedding batches (default: 3)",
+    )
+    parser.add_argument(
+        "--cleanup",
+        action="store_true",
+        help="Clean up orphaned chunks from deleted files",
+    )
+
+    return cast(argparse.ArgumentParser, parser)
+
+
+__all__: list[str] = ["add_package_subparser"]


### PR DESCRIPTION
## Summary
- support indexing packages directly from PyPI or GitHub using `uv`
- expose `package` subcommand in CLI for this feature
- document example usage in README

## Testing
- `pytest tests/test_config.py -q` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_6861026342b88328a469b2e8ff2ee01c